### PR TITLE
Update README with instructions to require file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Go to the terminal and update your gems using bundler:
 bundle install
 ```
 
-Right now, your project already has two new rake tasks: `backup` and `restore`.
+In the Rakefile of your project, add `require 'postgresql_backup'` anywhere **before** this line:
+
+```
+Rails.application.load_tasks
+```
+
+Right now, your project already has two new rake tasks: `postgresql_backup:dump` and `postgresql_backup:restore`.
 
 ## Configuration
 
@@ -39,6 +45,8 @@ Create a file inside the `config/initializers` folder. The name is not important
 Here is an example with all available options you can change:
 
 ```ruby
+require 'postgresql_backup'
+
 PostgresqlBackup.configure do |config|
   # This gem works with two possible repositories:
   #


### PR DESCRIPTION
[An issue](https://github.com/arturcp/postgresql-backup/issues/3) was opened because the gem was not working on ruby 2.7.6 and rails 6.1.4. This PR adds the instructions to make the gem work on those versions, which is basically add two more `requires` in two different files.

There was also an error on the names of the rake in one portion of the README, I am also update that to comply with the reality.