### PR TITLE
Add support to hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.0.8 - 2023-07-07
+
+- Add support to hooks (methods to run before/after dump and restore)
+
 ### v0.0.7 - 2022-04-19
 
 - Add support for ruby 3 and fog-aws 3.13.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgresql-backup (0.0.7)
+    postgresql-backup (0.0.8)
       fog-aws (~> 3.13.0)
       pastel (~> 0.8.0)
       tty-prompt (~> 0.23.0)
@@ -85,4 +85,4 @@ DEPENDENCIES
   simplecov (~> 0.21.2)
 
 BUNDLED WITH
-   2.3.11
+   2.4.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgresql-backup (0.0.9)
+    postgresql-backup (0.0.8)
       fog-aws (~> 3.13.0)
       pastel (~> 0.8.0)
       tty-prompt (~> 0.23.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgresql-backup (0.0.8)
+    postgresql-backup (0.0.9)
       fog-aws (~> 3.13.0)
       pastel (~> 0.8.0)
       tty-prompt (~> 0.23.0)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,25 +1,39 @@
+require_relative 'hooks'
+
 class Configuration
-  attr_accessor :repository, :backup_folder, :bucket, :region, :file_suffix,
-    :remote_path, :aws_access_key_id, :aws_secret_access_key
+  attr_accessor :aws_access_key_id,
+    :aws_secret_access_key,
+    :backup_folder,
+    :bucket,
+    :file_suffix,
+    :region,
+    :remote_path,
+    :repository
+
+  attr_reader :hooks
 
   def initialize(
-    repository: 'file system',
-    backup_folder: 'db/backups',
-    file_suffix: '',
     aws_access_key_id: '',
     aws_secret_access_key: '',
+    backup_folder: 'db/backups',
     bucket: '',
+    file_suffix: '',
     region: '',
-    remote_path: '_backups/database/'
+    remote_path: '_backups/database/',
+    repository: 'file system'
   )
-    @repository = repository
-    @backup_folder = backup_folder
-    @file_suffix = file_suffix
     @aws_access_key_id = aws_access_key_id
     @aws_secret_access_key = aws_secret_access_key
+    @backup_folder = backup_folder
     @bucket = bucket
+    @file_suffix = file_suffix
     @region = region
     @remote_path = remote_path
+    @repository = repository
+  end
+
+  def hooks=(hooks)
+    @hooks = Hooks.new(hooks)
   end
 
   def s3?

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -1,0 +1,29 @@
+class Hooks
+  def initialize(hooks)
+    @hooks = hooks
+  end
+
+  def before_restore
+    return unless @hooks.respond_to?(:before_restore)
+
+    @hooks.before_restore
+  end
+
+  def after_restore
+    return unless @hooks.respond_to?(:after_restore)
+
+    @hooks.after_restore
+  end
+
+  def before_dump
+    return unless @hooks.respond_to?(:before_dump)
+
+    @hooks.before_dump
+  end
+
+  def after_dump
+    return unless @hooks.respond_to?(:after_dump)
+
+    @hooks.after_dump
+  end
+end

--- a/lib/tools/database.rb
+++ b/lib/tools/database.rb
@@ -12,10 +12,14 @@ module Tools
     #
     # Return the full path of the backup file created in the disk.
     def dump(debug: false)
+      hooks.before_dump
+
       file_path = File.join(backup_folder, "#{file_name}#{file_suffix}.sql")
 
       cmd = "PGPASSWORD='#{password}' pg_dump -F p -v -O -U '#{user}' -h '#{host}' -d '#{database}' -f '#{file_path}' -p '#{port}' "
       debug ? system(cmd) : system(cmd, err: File::NULL)
+
+      hooks.after_dump
 
       file_path
     end
@@ -35,10 +39,14 @@ module Tools
     # If you need to make the command more verbose, pass
     # `debug: true` in the arguments of the function.
     def restore(file_name, debug: false)
+      hooks.before_restore
+
       file_path = File.join(backup_folder, file_name)
       output_redirection = debug ? '': ' > /dev/null'
       cmd = "PGPASSWORD='#{password}' psql -U '#{user}' -h '#{host}' -d '#{database}' -f '#{file_path}' -p '#{port}' #{output_redirection}"
       system(cmd)
+
+      hooks.after_restore
 
       file_path
     end
@@ -91,6 +99,10 @@ module Tools
           FileUtils.mkdir_p(folder)
         end
       end
+    end
+
+    def hooks
+      @hooks ||= configuration.hooks
     end
   end
 end

--- a/postgresql-backup.gemspec
+++ b/postgresql-backup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'postgresql-backup'
-  s.version     = '0.0.8'
+  s.version     = '0.0.9'
   s.summary     = "Automate PostgreSQL's backup and restore"
   s.description = "This gem automates PostgreSQL's backup and restore in your Rails project. It will inject two rake tasks that you can use to manage your data, either by using the local system or AWS S3 storage."
   s.authors     = ["Artur Caliendo Prado"]

--- a/postgresql-backup.gemspec
+++ b/postgresql-backup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'postgresql-backup'
-  s.version     = '0.0.9'
+  s.version     = '0.0.8'
   s.summary     = "Automate PostgreSQL's backup and restore"
   s.description = "This gem automates PostgreSQL's backup and restore in your Rails project. It will inject two rake tasks that you can use to manage your data, either by using the local system or AWS S3 storage."
   s.authors     = ["Artur Caliendo Prado"]

--- a/postgresql-backup.gemspec
+++ b/postgresql-backup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'postgresql-backup'
-  s.version     = '0.0.9'
+  s.version     = '0.0.7'
   s.summary     = "Automate PostgreSQL's backup and restore"
   s.description = "This gem automates PostgreSQL's backup and restore in your Rails project. It will inject two rake tasks that you can use to manage your data, either by using the local system or AWS S3 storage."
   s.authors     = ["Artur Caliendo Prado"]

--- a/postgresql-backup.gemspec
+++ b/postgresql-backup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'postgresql-backup'
-  s.version     = '0.0.7'
+  s.version     = '0.0.8'
   s.summary     = "Automate PostgreSQL's backup and restore"
   s.description = "This gem automates PostgreSQL's backup and restore in your Rails project. It will inject two rake tasks that you can use to manage your data, either by using the local system or AWS S3 storage."
   s.authors     = ["Artur Caliendo Prado"]

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../lib/configuration'
+require_relative '../lib/hooks'
 
 RSpec.describe Configuration do
   describe 'constructor' do
@@ -13,9 +14,12 @@ RSpec.describe Configuration do
       it { expect(subject.bucket).to be_empty }
       it { expect(subject.region).to be_empty }
       it { expect(subject.remote_path).to eq('_backups/database/') }
+      it { expect(subject.hooks).to be_a(Hooks) }
     end
 
     context 'with configuration values' do
+      let(:hooks) { double }
+
       subject do
         described_class.new(
           repository: 'repository',
@@ -25,7 +29,8 @@ RSpec.describe Configuration do
           aws_secret_access_key: 'aws_secret_access_key',
           bucket: 'bucket',
           region: 'region',
-          remote_path: 'remote_path'
+          remote_path: 'remote_path',
+          hooks: hooks,
         )
       end
 
@@ -37,6 +42,7 @@ RSpec.describe Configuration do
       it { expect(subject.bucket).to eq('bucket') }
       it { expect(subject.region).to eq('region') }
       it { expect(subject.remote_path).to eq('remote_path') }
+      it { expect(subject.hooks).to be_a(Hooks) }
     end
   end
 

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -1,0 +1,83 @@
+require_relative '../lib/hooks'
+
+RSpec.describe Hooks do
+  subject(:hooks) { described_class.new(configuration_hooks) }
+
+  context 'when configuration hooks is nil' do
+    let(:configuration_hooks) { nil }
+
+    it { expect(hooks.before_restore).to be_nil }
+    it { expect(hooks.after_restore).to be_nil }
+    it { expect(hooks.before_dump).to be_nil }
+    it { expect(hooks.after_dump).to be_nil }
+  end
+
+  context 'when configuration hooks is set but the hook does not contain the expected method' do
+    context 'but the hook class does not contain the expected methods' do
+      let(:configuration_hooks) { double }
+
+      it { expect(hooks.before_restore).to be_nil }
+      it { expect(hooks.after_restore).to be_nil }
+      it { expect(hooks.before_dump).to be_nil }
+      it { expect(hooks.after_dump).to be_nil }
+    end
+
+    context 'and the hook is an instance of a class that contains the expected methods' do
+      let(:my_class) do
+        Class.new do
+          def before_restore
+            'before restore'
+          end
+
+          def after_restore
+            'after restore'
+          end
+
+          def before_dump
+            'before dump'
+          end
+
+          def after_dump
+            'after dump'
+          end
+        end
+      end
+
+      let(:configuration_hooks) { my_class.new }
+
+      it { expect(hooks.before_restore).to eq('before restore') }
+      it { expect(hooks.after_restore).to eq('after restore') }
+      it { expect(hooks.before_dump).to eq('before dump') }
+      it { expect(hooks.after_dump).to eq('after dump') }
+    end
+
+    context 'and the hook is a class that contains the expected methods' do
+      let(:my_class) do
+        Class.new do
+          def self.before_restore
+            'before restore'
+          end
+
+          def self.after_restore
+            'after restore'
+          end
+
+          def self.before_dump
+            'before dump'
+          end
+
+          def self.after_dump
+            'after dump'
+          end
+        end
+      end
+
+      let(:configuration_hooks) { my_class }
+
+      it { expect(hooks.before_restore).to eq('before restore') }
+      it { expect(hooks.after_restore).to eq('after restore') }
+      it { expect(hooks.before_dump).to eq('before dump') }
+      it { expect(hooks.after_dump).to eq('after dump') }
+    end
+  end
+end


### PR DESCRIPTION
Backup and restore are working fine with the latest ruby versions, but sometimes we need to execute code in certain steps of the process. For example, you may need to send a message somewhere warning about a database restore before it happens, or after a dump is completed. Perhaps you use Elastic Search, Open Search, Algolia or even pg_search plugin, and need to reindex your data after a backup is restored.

The proposal on this pull request is to add hooks capabilities to the gem. By passing a class (or an instance of a class) in the configuration, you can execute custom code in any of these steps:

* before/after restore
* before/after dump

I am also modifying the documentation accordingly, so people can find information about the hooks on the README of the project.